### PR TITLE
generic Surfaces

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,7 @@ pub mod config;
 pub mod errors;
 pub mod font;
 pub mod platform;
+pub mod surface;
 pub mod source;
 pub mod util;
 

--- a/src/opengl/buffer.rs
+++ b/src/opengl/buffer.rs
@@ -84,12 +84,10 @@ impl Buffer {
             .into_iter()
             .map(|source| {
                 let frame = source.borrow().get_frame();
-                let raw = RawImage2d::from_raw_rgba_reversed(&frame.buffer, (frame.width, frame.height));
-                (
-                    source.clone(),
-                    RefCell::new(surface),
-                )
+                let raw =
+                    RawImage2d::from_raw_rgba_reversed(&frame.buffer, (frame.width, frame.height));
                 let surface = OpenGLSurface::new(facade.clone(), raw).unwrap();
+                (source.clone(), RefCell::new(surface))
             })
             .collect();
 

--- a/src/opengl/buffer.rs
+++ b/src/opengl/buffer.rs
@@ -19,6 +19,8 @@ use config::buffer_config::BufferConfig;
 use errors::*;
 use source::Source;
 use util::DerefInner;
+use surface::Surface as RenderSurface;
+use surface::OpenGLSurface;
 
 /// The `Buffer` struct, containing most things it needs to render
 pub struct Buffer {
@@ -29,7 +31,7 @@ pub struct Buffer {
     /// A shader program which it uses for rendering
     program: Program,
     /// An array of `Source`s which it uses as input
-    sources: Vec<(Rc<RefCell<Source>>, RefCell<Texture2d>)>,
+    sources: Vec<(Rc<RefCell<Source>>, RefCell<OpenGLSurface>)>,
     /// An array of dependency buffers which must render themselves before this
     depends: Vec<Rc<RefCell<Buffer>>>,
     /// Whether or not the buffer should resize from its original dimensions
@@ -83,11 +85,11 @@ impl Buffer {
             .into_iter()
             .map(|source| {
                 let frame = source.borrow().get_frame();
-                let raw =
-                    RawImage2d::from_raw_rgba_reversed(&frame.buffer, (frame.width, frame.height));
+                let raw = RawImage2d::from_raw_rgba_reversed(&frame.buffer, (frame.width, frame.height));
+                let mut surface = OpenGLSurface::new(facade.clone(), raw).unwrap();
                 (
                     source.clone(),
-                    RefCell::new(Texture2d::new(&*facade, raw).unwrap()),
+                    RefCell::new(surface),
                 )
             })
             .collect();
@@ -151,17 +153,13 @@ impl Buffer {
 
         for source in self.sources.iter() {
             if source.0.borrow_mut().update() {
-                let frame = source.0.borrow().get_frame();
-                let raw =
-                    RawImage2d::from_raw_rgba_reversed(&frame.buffer, (frame.width, frame.height));
-                source.1.replace(Texture2d::new(&*facade, raw)?);
+                use std::borrow::BorrowMut;
+
+                let mut surface_ref = source.1.borrow_mut();
+                source.0.borrow().write_frame((*surface_ref).borrow_mut())?;
             }
 
-            let texture = OwningHandle::new(&source.1);
-            let texture =
-                OwningHandle::new_with_fn(texture, |t| unsafe { DerefInner((*t).sampled()) });
-            let texture = MapAsUniform(texture, |t| &**t);
-            uniforms.push(source.0.borrow().get_name().to_string(), texture);
+            uniforms.push(source.0.borrow().get_name().to_string(), &source.1.borrow_mut().texture);
         }
 
         for buffer in self.depends.iter() {

--- a/src/opengl/mod.rs
+++ b/src/opengl/mod.rs
@@ -1,5 +1,6 @@
 //! Contains everything for the OpenGL renderer pipeline
 
+pub mod surface;
 pub mod buffer;
 pub mod renderer;
 pub mod text_renderer;

--- a/src/opengl/surface.rs
+++ b/src/opengl/surface.rs
@@ -1,0 +1,40 @@
+//! Surfaces which we can render to, backed by OpenGL textures.
+use glium::backend::Facade;
+use glium::texture::{RawImage2d, Texture2d, Texture2dDataSource};
+use std::rc::Rc;
+
+use errors::*;
+use surface::Surface;
+
+/// A `Surface` backed by a Glium `Texture2d`.
+pub struct OpenGLSurface {
+    texture: Texture2d,
+    facade: Rc<Facade>,
+}
+
+impl OpenGLSurface {
+    /// Returns a new `OpenGLSurface`, initialized with the specified `Texture2dDataSource`.
+    pub fn new<'a, T>(facade: Rc<Facade>, data: T) -> Result<OpenGLSurface>
+    where
+        T: Texture2dDataSource<'a>,
+    {
+        Ok(OpenGLSurface {
+            texture: Texture2d::new(&*facade, data)?,
+            facade: facade,
+        })
+    }
+
+    /// Returns a reference to the inner `Texture2d`.
+    pub fn ref_texture(&self) -> &Texture2d {
+        &self.texture
+    }
+}
+
+impl Surface for OpenGLSurface {
+    fn write_buffer(&mut self, buffer: &Vec<u8>, dimensions: (u32, u32)) -> Result<()> {
+        let raw = RawImage2d::from_raw_rgba_reversed(buffer, dimensions);
+        self.texture = Texture2d::new(&*self.facade, raw)?;
+
+        Ok(())
+    }
+}

--- a/src/source/image.rs
+++ b/src/source/image.rs
@@ -12,6 +12,7 @@ use time::{self, Duration, Tm};
 
 use super::{Frame, Source};
 use errors::*;
+use surface::Surface;
 
 /// A `Source` that reads an image from file and returns frames from that image
 pub struct ImageSource {
@@ -125,5 +126,12 @@ impl Source for ImageSource {
 
     fn get_frame(&self) -> Frame {
         self.frames[self.current_frame].0.clone()
+    }
+
+    fn write_frame(&self, surface: &mut Surface) -> Result<()> {
+        let ref frame = self.frames[self.current_frame].0;
+        surface.write_buffer(&frame.buffer, frame.dimensions())?;
+
+        Ok(())
     }
 }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -9,6 +9,7 @@ pub mod image;
 use std::path::Path;
 
 use errors::*;
+use surface::Surface;
 
 #[cfg(feature = "image-src")]
 pub use self::image::ImageSource;
@@ -38,4 +39,6 @@ pub trait Source {
     fn update(&mut self) -> bool;
     /// Gets the `Frame` for rendering
     fn get_frame(&self) -> Frame;
+    /// Writes the current `Frame` to a `Surface`.
+    fn write_frame(&self, surface: &mut Surface) -> Result<()>;
 }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -25,6 +25,14 @@ pub struct Frame {
     pub buffer: Vec<u8>,
 }
 
+impl Frame {
+    /// Returns the dimensions of this frame.
+    #[inline(always)]
+    pub fn dimensions(&self) -> (u32, u32) {
+        (self.width, self.height)
+    }
+}
+
 /// A `Source` is something that provides data to the renderer in the form of a `Frame` of RGBA
 /// image data
 pub trait Source {

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -1,0 +1,38 @@
+use std::rc::Rc;
+use std::cell::RefCell;
+use glium::backend::Facade;
+use glium::texture::{RawImage2d, Texture2d, Texture2dDataSource};
+
+use errors::*;
+
+/// A generic surface which we can render to.
+pub trait Surface {
+	/// Copies a buffer to the surface.
+    fn write_buffer(&mut self, buffer: &Vec<u8>, dimensions: (u32, u32)) -> Result<()>;
+}
+
+/// A `Surface` backed by a Glium `Texture2d`.
+pub struct OpenGLSurface {
+	pub texture: Texture2d,
+	facade: Rc<Facade>,
+}
+
+impl OpenGLSurface {
+	pub fn new<'a, T>(facade: Rc<Facade>, data: T) -> Result<OpenGLSurface>
+		where T: Texture2dDataSource<'a>
+	{
+		Ok(OpenGLSurface {
+			texture: Texture2d::new(&*facade, data)?,
+			facade: facade,
+		})
+	}
+}
+
+impl Surface for OpenGLSurface {
+	fn write_buffer(&mut self, buffer: &Vec<u8>, dimensions: (u32, u32)) -> Result<()> {
+		let raw = RawImage2d::from_raw_rgba_reversed(buffer, dimensions);
+		self.texture = Texture2d::new(&*self.facade, raw)?;
+
+		Ok(())
+	}
+}

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -1,38 +1,8 @@
-use std::rc::Rc;
-use std::cell::RefCell;
-use glium::backend::Facade;
-use glium::texture::{RawImage2d, Texture2d, Texture2dDataSource};
-
+//! Generic surface abstractions for textures.
 use errors::*;
 
 /// A generic surface which we can render to.
 pub trait Surface {
-	/// Copies a buffer to the surface.
+    /// Copies a buffer to the surface.
     fn write_buffer(&mut self, buffer: &Vec<u8>, dimensions: (u32, u32)) -> Result<()>;
-}
-
-/// A `Surface` backed by a Glium `Texture2d`.
-pub struct OpenGLSurface {
-	pub texture: Texture2d,
-	facade: Rc<Facade>,
-}
-
-impl OpenGLSurface {
-	pub fn new<'a, T>(facade: Rc<Facade>, data: T) -> Result<OpenGLSurface>
-		where T: Texture2dDataSource<'a>
-	{
-		Ok(OpenGLSurface {
-			texture: Texture2d::new(&*facade, data)?,
-			facade: facade,
-		})
-	}
-}
-
-impl Surface for OpenGLSurface {
-	fn write_buffer(&mut self, buffer: &Vec<u8>, dimensions: (u32, u32)) -> Result<()> {
-		let raw = RawImage2d::from_raw_rgba_reversed(buffer, dimensions);
-		self.texture = Texture2d::new(&*self.facade, raw)?;
-
-		Ok(())
-	}
 }


### PR DESCRIPTION
- [x] Design a `Surface` trait and backing types
- [x] Add `write_frame(&self, &mut Surface)` to `trait Source`
- [x] Implement this function on existing `Source`s
- [x] Switch `opengl::buffer::Buffer` to use `write_frame` instead of `get_frame`, avoiding a copy